### PR TITLE
Compile scala code by maven

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -34,11 +34,40 @@
   </dependencies>
 
   <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
     <plugins>
       <plugin>
         <groupId>io.gatling</groupId>
         <artifactId>gatling-maven-plugin</artifactId>
         <version>\${gatling-maven-plugin.version}</version>
+      </plugin>
+      <!-- plugin for compiling scala sources by maven plugin. see https://gatling.io/docs/current/installation#with-maven -->
+      <plugin>
+          <groupId>net.alchim31.maven</groupId>
+          <artifactId>scala-maven-plugin</artifactId>
+          <version>4.3.1</version>
+          <configuration>
+              <jvmArgs>
+                  <jvmArg>-Xss100M</jvmArg>
+              </jvmArgs>
+              <args>
+                  <arg>-target:jvm-1.8</arg>
+                  <arg>-deprecation</arg>
+                  <arg>-feature</arg>
+                  <arg>-unchecked</arg>
+                  <arg>-language:implicitConversions</arg>
+                  <arg>-language:postfixOps</arg>
+              </args>
+          </configuration>
+          <executions>
+              <execution>
+                  <goals>
+                      <goal>compile</goal>
+                      <goal>testCompile</goal>
+                  </goals>
+              </execution>
+          </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -34,40 +34,12 @@
   </dependencies>
 
   <build>
-    <sourceDirectory>src/main/scala</sourceDirectory>
     <testSourceDirectory>src/test/scala</testSourceDirectory>
     <plugins>
       <plugin>
         <groupId>io.gatling</groupId>
         <artifactId>gatling-maven-plugin</artifactId>
         <version>\${gatling-maven-plugin.version}</version>
-      </plugin>
-      <!-- plugin for compiling scala sources by maven plugin. see https://gatling.io/docs/current/installation#with-maven -->
-      <plugin>
-          <groupId>net.alchim31.maven</groupId>
-          <artifactId>scala-maven-plugin</artifactId>
-          <version>4.3.1</version>
-          <configuration>
-              <jvmArgs>
-                  <jvmArg>-Xss100M</jvmArg>
-              </jvmArgs>
-              <args>
-                  <arg>-target:jvm-1.8</arg>
-                  <arg>-deprecation</arg>
-                  <arg>-feature</arg>
-                  <arg>-unchecked</arg>
-                  <arg>-language:implicitConversions</arg>
-                  <arg>-language:postfixOps</arg>
-              </args>
-          </configuration>
-          <executions>
-              <execution>
-                  <goals>
-                      <goal>compile</goal>
-                      <goal>testCompile</goal>
-                  </goals>
-              </execution>
-          </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Make resulting project use of `scala-maven-plugin` according
https://gatling.io/docs/current/installation#with-maven manual
and compile projects scala source files by scala out-of-the-box.
IntelijIdea is now able to run generated object files (it knows
that it is scala compiled) and also maven can compile
generated project.